### PR TITLE
feat: cria endpoint de upload de histórico

### DIFF
--- a/fluxoagil/__init__.py
+++ b/fluxoagil/__init__.py
@@ -12,6 +12,7 @@ def create_app():
     app = Flask(__name__)
     api = Api(app)
     app.config['SECRET KEY'] = ''
+    app.config['MAX_CONTENT_LENGTH'] = 512 * 1024   # limits maximum allowed upload size to 512KiB
     api.add_resource(HelloFluxoAgil, '/')
     api.add_resource(AcademicHistory, '/academic-history')
     return app

--- a/fluxoagil/__init__.py
+++ b/fluxoagil/__init__.py
@@ -1,14 +1,17 @@
 from flask import Flask
 from flask_restful import Resource, Api
+from fluxoagil.views import AcademicHistory
+
 
 class HelloFluxoAgil(Resource):
     def get(self):
         return {'Welcome': 'to Fluxo Agil API'}
+
 
 def create_app():
     app = Flask(__name__)
     api = Api(app)
     app.config['SECRET KEY'] = ''
     api.add_resource(HelloFluxoAgil, '/')
+    api.add_resource(AcademicHistory, '/academic-history')
     return app
-    

--- a/fluxoagil/views.py
+++ b/fluxoagil/views.py
@@ -5,7 +5,7 @@ import uuid
 import os
 from utils import ContentExtractor
 
-UPLOAD_DIR = "fluxoagil/uploads/"
+UPLOAD_DIR = os.path.join(os.getcwd(), 'fluxoagil', 'uploads')
 
 class AcademicHistory(Resource):
     def __init__(self):
@@ -27,7 +27,7 @@ class AcademicHistory(Resource):
         file_name = file.filename
 
         if not AcademicHistory.allowed_file(file_name):
-            resp = jsonify({'error': 'Unallowed file extension (must be PDF)'})
+            resp = jsonify({'error': 'File type not supported (must be PDF)'})
             resp.status_code = 400
             return resp
 

--- a/fluxoagil/views.py
+++ b/fluxoagil/views.py
@@ -1,0 +1,31 @@
+from flask_restful import reqparse, Resource
+import werkzeug
+import uuid
+import os
+from utils import ContentExtractor
+
+UPLOAD_DIR = ""
+
+
+class AcademicHistory(Resource):
+    def __init__(self):
+        self.parser = reqparse.RequestParser()
+
+    def post(self):
+
+        self.parser.add_argument(
+            "file",
+            type=werkzeug.datastructures.FileStorage,
+            location="files")
+        args = self.parser.parse_args()
+
+        file = args.get("file")
+        file_name = str(uuid.uuid4()) + ".pdf"
+        file_path = os.path.join(UPLOAD_DIR, file_name)
+        file.save(file_path)
+
+        approved_courses = ContentExtractor(file_path).aproved_courses
+
+        os.remove(file_path)
+
+        return approved_courses


### PR DESCRIPTION
Adição do endpoint ```/academic-history``` para upload do histórico.

## Tipo de mudança

- [x] Feat
- [ ] Fix
- [ ] Docs

## Lista de controle

- [x] Eu li o guia de contribuição
- [x] Adicionei "reviewrs" e "assignees"
- [x] Adicionei documentação necessária
- [x] Meu código está de acordo com a pep8

### Para Feat:
- [x] A branch será mesclada com a dev

## Como testar o endpoint:

Primeiro execute o server:
```bash
python3 main.py
```

Em seguida, faça uma requisição POST com o arquivo pdf do histórico. Com o curl, pode ser feita com o seguinte comando, substituindo o endereço/porta e nome do arquivo se necessário:

```bash
curl http://127.0.0.1:5000/academic-history -v -X POST -F "file=@historico.pdf"
```

closes #4